### PR TITLE
Feature/precise latency

### DIFF
--- a/lib/mini_d3fl/job_controller/event_queue.ex
+++ b/lib/mini_d3fl/job_controller/event_queue.ex
@@ -19,9 +19,10 @@ defmodule MiniD3fl.JobController.EventQueue do
   end
 
   # コマンドをキューに挿入する関数
-  def insert_command(queue, %Event{time: time, event_name: _command, args: _args} = event) do
+  def insert_command(queue, %Event{time: time, event_name: command, args: args} = event) do
     # タプルとしてコマンドを構成し、時刻をキーにしてキューに挿入
-    :gb_trees.insert(time, event, queue)
+    #TODO: あとでcommandの間の優先順位をつけて、数値に変換するなど
+    :gb_trees.insert({time, command, args}, event, queue)
   end
 
   # 時刻順に最も早いコマンドを取得し、キューから削除
@@ -30,8 +31,8 @@ defmodule MiniD3fl.JobController.EventQueue do
   end
 
   def pop_command(queue) do
-    {value, event, new_queue} = :gb_trees.take_smallest(queue)
-    IO.puts(value)
+    {{time, _, _}, event, new_queue} = :gb_trees.take_smallest(queue)
+    IO.puts(time)
     {:ok, event, new_queue}
   end
 end

--- a/lib/mini_d3fl/job_executor.ex
+++ b/lib/mini_d3fl/job_executor.ex
@@ -143,7 +143,7 @@ defmodule MiniD3fl.JobExecutor do
         IO.puts "time #{time}: send from node_#{from_id} to node_#{to_id}"
 
       %Event{time: time, event_name: :recv, args: channel_pid} ->
-        Channel.send_model_from_channel(channel_pid)
+        Channel.send_model_from_channel(channel_pid, time)
 
         IO.puts "time #{time}: receive @channel"
         IO.inspect channel_pid

--- a/lib/mini_d3fl/job_executor.ex
+++ b/lib/mini_d3fl/job_executor.ex
@@ -14,8 +14,10 @@ defmodule MiniD3fl.JobExecutor do
               now_time: nil,
               CNs_to_Channel_pid_dict: nil,
               pid_to_CN_dict: nil,
-              pid_to_Channel_dict: nil
+              pid_to_Channel_dict: nil,
+              history: nil
   end
+
 
   defmodule JobExcInitArgs do
     @moduledoc """
@@ -101,18 +103,21 @@ defmodule MiniD3fl.JobExecutor do
   # end
 
   def handle_call({:simulate_execute}, _from, %State{job_controller_id: controller_id} = state) do
-    event_loop(controller_id)
-    {:reply, :ok, state}
+    init_history = []
+    history = event_loop(controller_id, init_history)
+    IO.inspect history
+    {:reply, history, %State{state | history: history}}
   end
 
-  def event_loop(job_controller_id) do
+  def event_loop(job_controller_id, history) do
     case GenServer.call(Utils.get_process_name(MiniD3fl.JobController, job_controller_id), {:get_event}) do
-      {:ok, event} ->
+      {:ok, %Event{time: time, event_name: name} = event} ->
         event_execute(job_controller_id, event)
-        event_loop(job_controller_id)
+        event_loop(job_controller_id, [%{time: time, event_name: name} | history])
       {:empty, _} ->
         IO.puts "Event Queue is Empty"
         IO.puts "=======SIMULATION END======="
+        history
       _ -> raise "ERROR"
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -21,6 +21,11 @@ defmodule MiniD3fl.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
+      {:axon, "~> 0.6", github:  "elixir-nx/axon"},
+      {:polaris, "~> 0.1"},
+      {:exla, "~> 0.6", github:  "elixir-nx/exla", sparse:  "exla", override: true},
+      {:nx, "~> 0.6", github:  "elixir-nx/nx", sparse:  "nx", override:  true},
+      {:scidata, "~> 0.1.11"}
       # {:dep_from_hexpm, "~> 0.3.0"},
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,15 @@
+%{
+  "axon": {:git, "https://github.com/elixir-nx/axon.git", "e5c8a37d8777356af5220eea03fc9e71bdf6fa4f", []},
+  "castore": {:hex, :castore, "0.1.22", "4127549e411bedd012ca3a308dede574f43819fe9394254ca55ab4895abfa1a2", [:mix], [], "hexpm", "c17576df47eb5aa1ee40cc4134316a99f5cad3e215d5c77b8dd3cfef12a22cac"},
+  "complex": {:hex, :complex, "0.5.0", "af2d2331ff6170b61bb738695e481b27a66780e18763e066ee2cd863d0b1dd92", [:mix], [], "hexpm", "2683bd3c184466cfb94fad74cbfddfaa94b860e27ad4ca1bffe3bff169d91ef1"},
+  "elixir_make": {:hex, :elixir_make, "0.9.0", "6484b3cd8c0cee58f09f05ecaf1a140a8c97670671a6a0e7ab4dc326c3109726", [:mix], [], "hexpm", "db23d4fd8b757462ad02f8aa73431a426fe6671c80b200d9710caf3d1dd0ffdb"},
+  "exla": {:git, "https://github.com/elixir-nx/exla.git", "f0b84c8ad04dc64702cade9de2294bee871d9b29", [sparse: "exla"]},
+  "jason": {:hex, :jason, "1.4.4", "b9226785a9aa77b6857ca22832cffa5d5011a667207eb2a0ad56adb5db443b8a", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "c5eb0cab91f094599f94d55bc63409236a8ec69a21a67814529e8d5f6cc90b3b"},
+  "nimble_csv": {:hex, :nimble_csv, "1.2.0", "4e26385d260c61eba9d4412c71cea34421f296d5353f914afe3f2e71cce97722", [:mix], [], "hexpm", "d0628117fcc2148178b034044c55359b26966c6eaa8e2ce15777be3bbc91b12a"},
+  "nimble_pool": {:hex, :nimble_pool, "1.1.0", "bf9c29fbdcba3564a8b800d1eeb5a3c58f36e1e11d7b7fb2e084a643f645f06b", [:mix], [], "hexpm", "af2e4e6b34197db81f7aad230c1118eac993acc0dae6bc83bac0126d4ae0813a"},
+  "nx": {:git, "https://github.com/elixir-nx/nx.git", "f0b84c8ad04dc64702cade9de2294bee871d9b29", [sparse: "nx"]},
+  "polaris": {:hex, :polaris, "0.1.0", "dca61b18e3e801ecdae6ac9f0eca5f19792b44a5cb4b8d63db50fc40fc038d22", [:mix], [{:nx, "~> 0.5", [hex: :nx, repo: "hexpm", optional: false]}], "hexpm", "13ef2b166650e533cb24b10e2f3b8ab4f2f449ba4d63156e8c569527f206e2c2"},
+  "scidata": {:hex, :scidata, "0.1.11", "fe3358bac7d740374b4f2a7eff6a1cb02e5ee7f87f7cdb1e8648ad93c533165f", [:mix], [{:castore, "~> 0.1", [hex: :castore, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}, {:nimble_csv, "~> 1.1", [hex: :nimble_csv, repo: "hexpm", optional: false]}, {:stb_image, "~> 0.4", [hex: :stb_image, repo: "hexpm", optional: true]}], "hexpm", "90873337a9d5fe880d640517efa93d3c07e46c8ba436de44117f581800549f93"},
+  "telemetry": {:hex, :telemetry, "1.3.0", "fedebbae410d715cf8e7062c96a1ef32ec22e764197f70cda73d82778d61e7a2", [:rebar3], [], "hexpm", "7015fc8919dbe63764f4b4b87a95b7c0996bd539e0d499be6ec9d7f3875b79e6"},
+  "xla": {:hex, :xla, "0.8.0", "fef314d085dd3ee16a0816c095239938f80769150e15db16dfaa435553d7cb16", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm", "739c61c8d93b97e12ba0369d10e76130224c208f1a76ad293e3581f056833e57"},
+}

--- a/test/mini_d3fl/compute_node_test.exs
+++ b/test/mini_d3fl/compute_node_test.exs
@@ -67,7 +67,7 @@ defmodule MiniD3fl.ComputeNodeTest do
     {:ok, channel_pid} = Channel.start_link(init_args)
     model1 = %Model{size: 50, plain_model: "sample_plain_model"}
     :ok = Channel.recv_model_at_channel(channel_pid, model1, 10)
-    :ok = Channel.send_model_from_channel(channel_pid)
+    :ok = Channel.send_model_from_channel(channel_pid, 20)
 
     %ComputeNode.State{receive_model: recv_model} = ComputeNode.get_state(20)
     assert recv_model == model1
@@ -115,7 +115,7 @@ defmodule MiniD3fl.ComputeNodeTest do
     assert queue == received_queue
     assert model_sum_size == model1.size
 
-    :ok = Channel.send_model_from_channel(channel_pid)
+    :ok = Channel.send_model_from_channel(channel_pid, 20)
 
     %ComputeNode.State{receive_model: recv_model} = ComputeNode.get_state(20)
     assert recv_model == nil
@@ -167,7 +167,7 @@ defmodule MiniD3fl.ComputeNodeTest do
 
     # model1 の送受信
 
-    :ok = Channel.send_model_from_channel(channel_pid)
+    :ok = Channel.send_model_from_channel(channel_pid, 30)
     %ComputeNode.State{receive_model: recv_model} = ComputeNode.get_state(20)
     assert recv_model == model1
 
@@ -178,7 +178,7 @@ defmodule MiniD3fl.ComputeNodeTest do
 
     # model2 の送受信
 
-    :ok = Channel.send_model_from_channel(channel_pid)
+    :ok = Channel.send_model_from_channel(channel_pid, 40)
     %ComputeNode.State{receive_model: recv_model} = ComputeNode.get_state(20)
     assert recv_model == model2
 

--- a/test/mini_d3fl/job_executor_test.exs
+++ b/test/mini_d3fl/job_executor_test.exs
@@ -15,11 +15,38 @@ defmodule MiniD3fl.JobExecutorTest do
       queue = EventQueue.insert_command(queue,%Event{time: 7, event_name: :train, args: %TrainArgs{node_id: 20}})
 
       job_controller_id = 0
-      {:ok, pid} = JobController.start_link(
+      {:ok, _pid} = JobController.start_link(
         %{job_controller_id: job_controller_id,
         init_event_queue: queue})
       %{job_controller_id: job_controller_id, queue: queue}
   end
+
+  def setup_job_controller_precise(channel_pid) do
+    # キューの初期化
+    queue = EventQueue.init_queue()
+
+    # コマンドを挿入
+    queue = EventQueue.insert_command(queue,%Event{time: 5, event_name: :train, args: %TrainArgs{node_id: 10}})
+    queue = EventQueue.insert_command(queue,%Event{time: 10, event_name: :send, args: %SendArgs{from_node_id: 10,
+                                                                                        to_node_id: 20,
+                                                                                        channel_pid: channel_pid,
+                                                                                        time: 10}})
+    queue = EventQueue.insert_command(queue,%Event{time: 11, event_name: :send, args: %SendArgs{from_node_id: 10,
+                                                                                        to_node_id: 20,
+                                                                                        channel_pid: channel_pid,
+                                                                                        time: 11}})
+    queue = EventQueue.insert_command(queue,%Event{time: 12, event_name: :send, args: %SendArgs{from_node_id: 10,
+                                                                                        to_node_id: 20,
+                                                                                        channel_pid: channel_pid,
+                                                                                        time: 12}})
+    queue = EventQueue.insert_command(queue,%Event{time: 7, event_name: :train, args: %TrainArgs{node_id: 20}})
+
+    job_controller_id = 0
+    {:ok, _pid} = JobController.start_link(
+      %{job_controller_id: job_controller_id,
+      init_event_queue: queue})
+    %{job_controller_id: job_controller_id, queue: queue}
+end
 
   def setup_compute_node(node_id) do
     args = %InitArgs{node_id: node_id,
@@ -31,11 +58,10 @@ defmodule MiniD3fl.JobExecutorTest do
     %{node_id: node_id}
   end
 
-  def setup_channel() do
+  def setup_channel(bandwidth \\ 100) do
     # Channelの初期設定
-    # TODO: 関数化して切り出す（channel_testの中の共通部分も）
 
-    input_qos = %Channel.QoS{bandwidth: 100,
+    input_qos = %Channel.QoS{bandwidth: bandwidth,
                       packetloss: 0,
                       capacity: 100}
 
@@ -44,21 +70,64 @@ defmodule MiniD3fl.JobExecutorTest do
                   to_cn_id: 20,
                   QoS: input_qos}
 
-    {:ok, channel_pid} = Channel.start_link(init_args)
+    {:ok, _channel_pid} = Channel.start_link(init_args)
   end
 
-  setup do
+  def setup_rough(bandwidth \\ 100) do
     setup_compute_node(10)
     setup_compute_node(20)
-    {:ok, channel_pid} = setup_channel()
+    {:ok, channel_pid} = setup_channel(bandwidth)
     setup_job_controller(channel_pid)
   end
 
-  test "should exec JobExecutor", %{job_controller_id: job_controller_id, queue: queue} do
+  def setup_precise(bandwidth \\ 1) do
+    setup_compute_node(10)
+    setup_compute_node(20)
+    {:ok, channel_pid} = setup_channel(bandwidth)
+    setup_job_controller_precise(channel_pid)
+  end
+
+  test "should exec JobExecutor" do
+    %{job_controller_id: job_controller_id, queue: queue} = setup_rough()
     job_executor_id = 0
     JobExecutor.start_link(%JobExcInitArgs{job_executor_id: job_executor_id, job_controller_id: job_controller_id, init_event_queue: queue})
 
-    JobExecutor.simulate_execute(0)
+    history = JobExecutor.simulate_execute(0)
     #TODO: ADD test (timeline, inner state)
+
+    desired_history = [
+      %{time: 11, event_name: :complete_train},
+      %{time: 10.1, event_name: :recv},
+      %{time: 10, event_name: :send},
+      %{time: 9, event_name: :complete_train},
+      %{time: 7, event_name: :train},
+      %{time: 5, event_name: :train}
+    ]
+
+    assert history == desired_history
+  end
+
+  test "should exec JobExecutor with precise latency" do
+    %{job_controller_id: job_controller_id, queue: queue} = setup_precise()
+    job_executor_id = 0
+    JobExecutor.start_link(%JobExcInitArgs{job_executor_id: job_executor_id, job_controller_id: job_controller_id, init_event_queue: queue})
+
+    history = JobExecutor.simulate_execute(0)
+    #TODO: ADD test (timeline, inner state)
+
+    desired_history = [
+      %{time: 40.0, event_name: :recv},
+      %{time: 30.0, event_name: :recv},
+      %{time: 20.0, event_name: :recv},
+      %{time: 12, event_name: :send},
+      %{time: 11, event_name: :send},
+      %{event_name: :complete_train, time: 11},
+      %{event_name: :send, time: 10},
+      %{event_name: :complete_train, time: 9},
+      %{event_name: :train, time: 7},
+      %{event_name: :train, time: 5}
+    ]
+
+    assert history == desired_history
   end
 end


### PR DESCRIPTION
## Feature: caluculate presice latency regarding to the packet remaint

---

## Summary  
- What issue does this address?  
In the previous implementation, a packet in a channel could only have two states: either it had arrived at the channel or it had been sent to another compute node. These two states did not allow for representing a packet that was in the process of being sent.